### PR TITLE
Replace iris with mtcars

### DIFF
--- a/_episodes_rmd/06-data-subsetting.Rmd
+++ b/_episodes_rmd/06-data-subsetting.Rmd
@@ -616,7 +616,7 @@ lista, pero no quieres *extraer* un elemento, entonces probablemente usarás
 
 
 ```{r}
-xlist <- list(a = "Software Carpentry", b = 1:10, data = head(iris))
+xlist <- list(a = "Software Carpentry", b = 1:10, data = head(mtcars))
 xlist[1]
 ```
 
@@ -675,7 +675,7 @@ xlist$data
 >
 >
 > ```{r, eval=FALSE}
-> xlist <- list(a = "Software Carpentry", b = 1:10, data = head(iris))
+> xlist <- list(a = "Software Carpentry", b = 1:10, data = head(mtcars))
 > ```
 >
 >


### PR DESCRIPTION
Replaces example using `iris` dataset with example using `mtcars` dataset to avoid using data created by a eugenicist.
