### PR TITLE
make lesson suitable for teaching with locally-built pages

### DIFF
--- a/_extras/about.md
+++ b/_extras/about.md
@@ -1,6 +1,4 @@
 ---
-layout: page
 title: About
-permalink: /about/
 ---
 {% include carpentries.html %}

--- a/_extras/discuss.md
+++ b/_extras/discuss.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Discussion
-permalink: /discuss/
 ---
 Please see [our other R lesson][r-gap] for a different presentation of these concepts.
 

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: "Guía del instructor"
-permalink: /guide/
 ---
 
 ## Tiempo
@@ -14,8 +12,8 @@ si no lo hiciste).
 ## Planificación de la lección
 
 La lección contiene mucho más material del que puede ser enseñado en un día.
-Los instructores deberán elegir un subgrupo apropiado de episodios a usar 
-para un curso estándar de un día de duración. 
+Los instructores deberán elegir un subgrupo apropiado de episodios a usar
+para un curso estándar de un día de duración.
 
 Algunos lineamientos sugeridos del material a utilizar son:
 
@@ -34,10 +32,10 @@ Algunos lineamientos sugeridos del material a utilizar son:
 * 02 Gestión de proyectos con RStudio
 * 03 Buscando ayuda
 * 04 Estructuras de datos
-* 05 Explorando data frames 
+* 05 Explorando data frames
 * 06 Haciendo subconjuntos de datos
 * 09 Vectorization
-* 08 Creando gráficas con calidad para publicación con ggplot2 *OR* 
+* 08 Creando gráficas con calidad para publicación con ggplot2 *OR*
 13 Manipulación de data frames con dplyr
 * 15 Produciendo informes con knitr
 
@@ -51,14 +49,14 @@ Medio día de curso podría consistir en (sugerido por [@karawoo](https://github
 
 ## Configurando git en RStudio
 
-Pueden haber dificultades relacionando git a RStudio dependiendo del 
+Pueden haber dificultades relacionando git a RStudio dependiendo del
 sistema operativo y de su versión. Para asegurarse que Git está correctamente
 instalado y configurado, los alumnos deberán ir a la ventana Opciones de
 la aplicación RStudio.
 
 * **Mac OS X:**
   * Ir a RStudio -> Preferencias... -> Git/SVN
-  * Chequear si existe un **path** a un archivo en la ventana "Git ejecutable". Si no lo hay, el siguiente desafío será averiguar dónde está ubicado Git. 
+  * Chequear si existe un **path** a un archivo en la ventana "Git ejecutable". Si no lo hay, el siguiente desafío será averiguar dónde está ubicado Git.
   * En la terminal, ingresa `which git` y obtendrás el **path** al archivo ejecutable de git. En la ventana "Git ejecutable" quizás tengas dificultades encontrando el directorio, ya que OS X oculta muchos de sus archivos del sistema operativo. Con la ventana de selección de archivo abierta, presionar las teclas "Comando-Shift-G" hará que se abra un cuadro de texto donde podrás tipear o pegar el **path** completo a tu archivo ejecutable de Git: e.g. /usr/bin/git o lo que corresponda.
 * **Windows:**
   * Ir a Herramientas -> Opciones Globales... -> Git/SVN
@@ -73,7 +71,7 @@ $ git config --global credential.helper 'cache --timeout=10000000'
 
 ## Obteniendo datos
 
-La forma más simple de obtener los datos usados en esta lección durante un taller es 
+La forma más simple de obtener los datos usados en esta lección durante un taller es
 hacer que los asistentes ejecuten lo siguiente:
 
 ~~~
@@ -90,28 +88,28 @@ Los asistentes pueden usar el diálogo `Archivo - Guardar como...` de su navegad
 
 ## En general
 
-Asegurarse de enfatizar las buenas prácticas: escribir el código en **scripts** y hacer 
+Asegurarse de enfatizar las buenas prácticas: escribir el código en **scripts** y hacer
 que esté bajo control de versiones. Alentar a los estudiantes a crear archivos de **scripts**
-para resolver los desafíos. 
+para resolver los desafíos.
 
 Si estás trabajando en un ambiente remoto (en "la nube"), puedes pedirles que suban los datos de **gapminder**
-luego de la segunda lección. 
+luego de la segunda lección.
 
 Asegurate de enfatizar que, a fin de cuentas, las matrices son vectores y que las **data frames**
-son listas: esto explicará mucho del comportamiento esotérico encontrado 
+son listas: esto explicará mucho del comportamiento esotérico encontrado
 en las operaciones básicas.
 
-El reciclado de vectores y funciones probablemente se explican mejor usando 
+El reciclado de vectores y funciones probablemente se explican mejor usando
 diagramas en una pizarra.
 
-Es recomendado mirar y hacer los ejemplos de una página de ayuda de R: los 
-archivos de ayuda pueden ser intimidantes al principio, pero saber cómo leerlos es 
+Es recomendado mirar y hacer los ejemplos de una página de ayuda de R: los
+archivos de ayuda pueden ser intimidantes al principio, pero saber cómo leerlos es
 tremendamente útil.
 
 Mostrar las **CRAN task views**, verlas con uno de los temas.
 
 Hay mucho contenido: muévete rápidamente por las primeras lecciones. Éstas son extensas
-mayormente con el propósito de aprender por ósmosis: de forma que su recuerdo 
+mayormente con el propósito de aprender por ósmosis: de forma que su recuerdo
 se dispare cuando se encuentren luego con un problema o comportamiento esotérico.
 
 Lecciones clave en las cuales dedicar tiempo:
@@ -121,7 +119,7 @@ Lecciones clave en las cuales dedicar tiempo:
 * Estructuras de datos - vale la pena ser completo, pero puedes avanzar por la lección rápidamente.
 
 No se preocupes por no equivocarte o conocer el material de pies a cabeza. Usa
-los errores como momentos de aprendizaje: la habilidad más importante que puedes 
+los errores como momentos de aprendizaje: la habilidad más importante que puedes
 enseñar es cómo eliminar errores (**debug**) y recuperarse de errores inesperados.
 
 [gapminder-data]: https://raw.githubusercontent.com/swcarpentry/r-novice-gapminder/gh-pages/_episodes_rmd/data/gapminder-FiveYearData.csv

--- a/setup.md
+++ b/setup.md
@@ -1,5 +1,4 @@
 ---
-layout: page
 title: Configuración
 ---
 


### PR DESCRIPTION
See discussion here for more background: https://github.com/datacarpentry/datacarpentry.github.io/issues/542

In short, some Carpentries lessons use the path `/guide/` for their Instructor Notes page and others use `/guide/index.html` (the default defined in `_config.yml`). This PR removes permalinks with a trailing slash from the YAML front matter of the Instructor Notes (`_extras/guide.md`) and other Extras files, consistent with new lessons created with [the lesson template](https://github.com/carpentries/styles/). Although there's no functional difference in the online versions of the lesson pages, pages with a trailing slash in the permalink will result in **broken links in the version of the lesson built locally**. We'd like local builds to be usable e.g. in workshops taking place at locations with limited or unreliable Internet access. 

Keeping the paths to these files consistent will also help us avoid broken links on the [Software Carpentry Lessons page](https://software-carpentry.org/lessons/), and ensure that equivalent paths in new lessons created with the template are consistent with previously-developed lessons like this one.

I did a sweep through the lesson and adjusted internal links as part of this PR. If and when this is merged, I'll also make sure the link on https://software-carpentry.org/lessons/ to the Instructor Notes page isn't broken, and make another sweep through the lesson pages too. 

Finally, I also removed the `layout` field from several pages, as the default layout is already set for Episodes and Extras pages in `_config.yml`.