### PR TITLE
update workflows to match current styles

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -8,14 +8,16 @@ jobs:
     name: ${{ matrix.lesson-name }} (${{ matrix.os-name }})
     if: github.repository == 'carpentries/styles'
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
         lesson: [swcarpentry/shell-novice, datacarpentry/r-intro-geospatial, librarycarpentry/lc-git]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
+        experimental: [false]
         include:
-          - os: ubuntu-latest
-            os-name: Ubuntu
+          - os: ubuntu-20.04
+            os-name: Linux
           - os: macos-latest
             os-name: macOS
           - os: windows-latest
@@ -26,16 +28,27 @@ jobs:
             lesson-name: (DC) R Intro Geospatial
           - lesson: librarycarpentry/lc-git
             lesson-name: (LC) Intro to Git
+          - lesson: datacarpentry/astronomy-python
+            lesson-name: (DC) Foundations of Astronomical Data Science
+            experimental: true
+            os: ubuntu-20.04
+            os-name: Linux
+          - lesson: carpentries/lesson-example
+            lesson-name: (CP) Lesson Example
+            experimental: false
+            os: ubuntu-20.04
+            os-name: Linux
     defaults:
       run:
         shell: bash # forces 'Git for Windows' on Windows
     env:
-      RSPM: 'https://packagemanager.rstudio.com/cran/__linux__/bionic/latest'
+      RSPM: 'https://packagemanager.rstudio.com/cran/__linux__/focal/latest'
     steps:
       - name: Set up Ruby
-        uses: actions/setup-ruby@main
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7.1'
+          ruby-version: '2.7'
+          bundler-cache: true
 
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -44,7 +57,7 @@ jobs:
 
       - name: Install GitHub Pages, Bundler, and kramdown gems
         run: |
-          gem install github-pages bundler kramdown
+          gem install github-pages bundler kramdown kramdown-parser-gfm
 
       - name: Install Python modules
         run: |
@@ -61,25 +74,54 @@ jobs:
           path: lesson
           fetch-depth: 0
 
-      - name: Determine the proper reference to use
-        id: styles-ref
-        run: |
-          if [[ -n "${{ github.event.pull_request.number }}" ]]; then
-            echo "::set-output name=ref::refs/pull/${{ github.event.pull_request.number }}/head"
-          else
-            echo "::set-output name=ref::gh-pages"
-          fi
-
       - name: Sync lesson with carpentries/styles
         working-directory: lesson
         run: |
+          echo "::group::Fetch Styles"
+          if [[ -n "${{ github.event.pull_request.number }}" ]]
+          then
+            ref="refs/pull/${{ github.event.pull_request.number }}/head"
+          else
+            ref="gh-pages"
+          fi
+
           git config --global user.email "team@carpentries.org"
           git config --global user.name "The Carpentries Bot"
+
           git remote add styles https://github.com/carpentries/styles.git
-          git config --local remote.styles.tagOpt --no-tags
-          git fetch styles ${{ steps.styles-ref.outputs.ref }}:styles-ref
-          git merge -s recursive -Xtheirs --no-commit styles-ref
-          git commit -m "Sync lesson with carpentries/styles"
+          git fetch styles $ref:styles-ref
+          echo "::endgroup::"
+          echo "::group::Synchronize Styles"
+          # Sync up only if necessary
+          if [[ $(git rev-list --count HEAD..styles-ref) != 0 ]]
+          then
+
+            # The merge command below might fail for lessons that use remote theme
+            # https://github.com/carpentries/carpentries-theme
+            echo "Testing merge using recursive strategy, accepting upstream changes without committing"
+            if ! git merge -s recursive -Xtheirs --no-commit styles-ref
+            then
+
+              # Remove "deleted by us, unmerged" files from the staging area.
+              # these are the files that were removed from the lesson
+              # but are still present in the carpentries/styles repo
+              echo "Removing previously deleted files"
+              git rm $(git diff --name-only --diff-filter=DU)
+
+              # If there are still "unmerged" files,
+              # let's raise an error and look into this more closely
+              if [[ -n $(git diff --name-only --diff-filter=U) ]]
+              then
+                echo "There were unmerged files in ${{ matrix.lesson-name }}:"
+                echo "$(git diff --compact-summary --diff-filter=U)"
+                exit 1
+              fi
+            fi
+
+            echo "Committing changes"
+            git commit -m "Sync lesson with carpentries/styles"
+          fi
+          echo "::endgroup::"
 
       - name: Look for R-markdown files
         id: check-rmd
@@ -93,12 +135,13 @@ jobs:
         with:
           use-public-rspm: true
           install-r: false
-          r-version: 'release'
 
       - name: Install needed packages
         if: steps.check-rmd.outputs.count != 0
+        working-directory: lesson
         run: |
-          install.packages(c('remotes', 'rprojroot', 'renv', 'desc', 'rmarkdown', 'knitr'))
+          source('bin/dependencies.R')
+          install_required_packages(.libPaths()[1])
         shell: Rscript {0}
 
       - name: Query dependencies
@@ -108,17 +151,23 @@ jobs:
           source('bin/dependencies.R')
           deps <- identify_dependencies()
           create_description(deps)
+          use_bioc_repos()
           saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
           writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
         shell: Rscript {0}
 
-      - name: Cache R packages
+      - name: Restore Package Cache
         if: runner.os != 'Windows' && steps.check-rmd.outputs.count != 0
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
           restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+
+      - name: Install stringi from source
+        if: runner.os == 'Linux' && steps.check-rmd.outputs.count != 0
+        run: install.packages('stringi', repos='https://cloud.r-project.org')
+        shell: Rscript {0}
 
       - name: Install system dependencies for R packages
         if: runner.os == 'Linux' && steps.check-rmd.outputs.count != 0
@@ -126,8 +175,11 @@ jobs:
         run: |
           while read -r cmd
           do
-            eval sudo $cmd
-          done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "18.04"), sep = "\n")')
+            eval sudo $cmd || echo "Nothing to update"
+          done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "20.04"), sep = "\n")')
 
       - run: make site
+        working-directory: lesson
+
+      - run: make lesson-check-all
         working-directory: lesson

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,20 +1,26 @@
 name: Website
 on:
   push:
-    branches: gh-pages
+    branches:
+      - gh-pages
+      - main
   pull_request: []
 jobs:
   build-website:
-    if: github.repository != 'carpentries/styles' && (github.repository_owner == 'swcarpentry' || github.repository_owner == 'datacarpentry' || github.repository_owner == 'librarycarpentry' || github.repository_owner == 'carpentries')
-    runs-on: ubuntu-latest
+    if: ${{ !endsWith(github.repository, '/styles') }}
+    runs-on: ubuntu-20.04
+    env:
+      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     defaults:
       run:
         shell: bash
     steps:
       - name: Set up Ruby
-        uses: actions/setup-ruby@main
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7.1'
+          ruby-version: '2.7'
+          bundler-cache: true
 
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -23,7 +29,7 @@ jobs:
 
       - name: Install GitHub Pages, Bundler, and kramdown gems
         run: |
-          gem install github-pages bundler kramdown
+          gem install github-pages bundler kramdown kramdown-parser-gfm
 
       - name: Install Python modules
         run: |
@@ -46,12 +52,20 @@ jobs:
         with:
           use-public-rspm: true
           install-r: false
-          r-version: 'release'
+
+      - name: Restore R Cache
+        if: steps.check-rmd.outputs.count != 0
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
       - name: Install needed packages
         if: steps.check-rmd.outputs.count != 0
         run: |
-          install.packages(c('remotes', 'rprojroot', 'renv', 'desc', 'rmarkdown', 'knitr'))
+          source('bin/dependencies.R')
+          install_required_packages()
         shell: Rscript {0}
 
       - name: Query dependencies
@@ -60,28 +74,50 @@ jobs:
           source('bin/dependencies.R')
           deps <- identify_dependencies()
           create_description(deps)
+          use_bioc_repos()
           saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
           writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
         shell: Rscript {0}
 
-      - name: Cache R packages
-        if: steps.check-rmd.outputs.count != 0
-        uses: actions/cache@v1
-        with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
       - name: Install system dependencies for R packages
         if: steps.check-rmd.outputs.count != 0
         run: |
           while read -r cmd
           do
-            eval sudo $cmd
-          done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "18.04"), sep = "\n")')
+            eval sudo $cmd || echo "Nothing to update"
+          done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "20.04"), sep = "\n")')
 
-      - run: make site
-      - run: make lesson-check
-        if: always()
+      - name: Render the markdown and confirm that the site can be built
+        run: make site
+
+      - name: Checkout github pages
+        if: ${{ github.event_name == 'push' && steps.check-rmd.outputs.count != 0 && github.ref != 'refs/heads/gh-pages'}}
+        uses: actions/checkout@master
+        with:
+          ref: gh-pages
+          path: gh-pages
+
+      - name: Commit and Push
+        if: ${{ github.event_name == 'push' && steps.check-rmd.outputs.count != 0 && github.ref != 'refs/heads/gh-pages'}}
+        run: |
+          # clean up gh-pages
+          cd gh-pages
+          git rm -rf .           # remove all previous files
+          git restore --staged . # remove things from the stage
+          cd ..
+          # copy everything into gh-pages site
+          cp -r `ls -A | grep -v 'gh-pages' | grep -v '.git' | grep -v '.bundle/' | grep -v '_site'` gh-pages
+          # move into gh-pages, add, commit, and push
+          cd gh-pages
+          # setup git
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
+          git add -A .
+          git commit --allow-empty -m "[Github Actions] render website (via ${{ github.sha }})"
+          git push origin gh-pages
+          # return
+          cd ..
+
       - run: make lesson-check-all
         if: always()

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,13 @@
 
 source 'https://rubygems.org'
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Synchronize with https://pages.github.com/versions
-ruby '>=2.5.8'
+ruby '>=2.7.1'
 
 gem 'github-pages', group: :jekyll_plugins
+
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.0.0')
+    gem 'webrick', '>= 1.6.1'
+end

--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,19 @@
 
 # Settings
 MAKEFILES=Makefile $(wildcard *.mk)
-JEKYLL=bundle config --local set path .vendor/bundle && bundle install && bundle update && bundle exec jekyll
+JEKYLL=bundle config set --local path .vendor/bundle && bundle install && bundle update && bundle exec jekyll
 PARSER=bin/markdown_ast.rb
 DST=_site
+
+# Find Docker
+DOCKER := $(shell which docker 2>/dev/null)
 
 # Check Python 3 is installed and determine if it's called via python3 or python
 # (https://stackoverflow.com/a/4933395)
 PYTHON3_EXE := $(shell which python3 2>/dev/null)
 ifneq (, $(PYTHON3_EXE))
   ifeq (,$(findstring Microsoft/WindowsApps/python3,$(subst \,/,$(PYTHON3_EXE))))
-    PYTHON := python3
+    PYTHON := $(PYTHON3_EXE)
   endif
 endif
 
@@ -21,18 +24,16 @@ ifeq (,$(PYTHON))
   ifneq (, $(PYTHON_EXE))
     PYTHON_VERSION_FULL := $(wordlist 2,4,$(subst ., ,$(shell python --version 2>&1)))
     PYTHON_VERSION_MAJOR := $(word 1,${PYTHON_VERSION_FULL})
-    ifneq (3, ${PYTHON_VERSION_MAJOR})
-      $(error "Your system does not appear to have Python 3 installed.")
+    ifeq (3, ${PYTHON_VERSION_MAJOR})
+      PYTHON := $(PYTHON_EXE)
+    else
+      PYTHON_NOTE = "Your system does not appear to have Python 3 installed."
     endif
-    PYTHON := python
   else
-      $(error "Your system does not appear to have any Python installed.")
+      PYTHON_NOTE = "Your system does not appear to have any Python installed."
   endif
 endif
 
-
-# Controls
-.PHONY : commands clean files
 
 # Default target
 .DEFAULT_GOAL := commands
@@ -40,27 +41,33 @@ endif
 ## I. Commands for both workshop and lesson websites
 ## =================================================
 
+.PHONY: site docker-serve repo-check clean clean-rmd
+
 ## * serve            : render website and run a local server
-serve : lesson-md
+serve : lesson-md index.md
 	${JEKYLL} serve
 
 ## * site             : build website but do not run a server
-site : lesson-md
+site : lesson-md index.md
 	${JEKYLL} build
 
 ## * docker-serve     : use Docker to serve the site
 docker-serve :
-	docker pull carpentries/lesson-docker:latest
-	docker run --rm -it \
+ifeq (, $(DOCKER))
+	$(error Your system does not appear to have Docker installed)
+else
+	@$(DOCKER) pull carpentries/lesson-docker:latest
+	@$(DOCKER) run --rm -it \
 		-v $${PWD}:/home/rstudio \
 		-p 4000:4000 \
 		-p 8787:8787 \
 		-e USERID=$$(id -u) \
 		-e GROUPID=$$(id -g) \
 		carpentries/lesson-docker:latest
+endif
 
 ## * repo-check       : check repository settings
-repo-check :
+repo-check : python
 	@${PYTHON} bin/repo_check.py -s .
 
 ## * clean            : clean up junk files
@@ -68,6 +75,9 @@ clean :
 	@rm -rf ${DST}
 	@rm -rf .sass-cache
 	@rm -rf bin/__pycache__
+	@rm -rf .vendor
+	@rm -rf .bundle
+	@rm -f Gemfile.lock
 	@find . -name .DS_Store -exec rm {} \;
 	@find . -name '*~' -exec rm {} \;
 	@find . -name '*.pyc' -exec rm {} \;
@@ -85,7 +95,7 @@ clean-rmd :
 .PHONY : workshop-check
 
 ## * workshop-check   : check workshop homepage
-workshop-check :
+workshop-check : python
 	@${PYTHON} bin/workshop_check.py .
 
 
@@ -96,7 +106,7 @@ workshop-check :
 .PHONY : lesson-check lesson-md lesson-files lesson-fixme install-rmd-deps
 
 # RMarkdown files
-RMD_SRC = $(wildcard _episodes_rmd/??-*.Rmd)
+RMD_SRC = $(wildcard _episodes_rmd/*.Rmd)
 RMD_DST = $(patsubst _episodes_rmd/%.Rmd,_episodes/%.md,$(RMD_SRC))
 
 # Lesson source files in the order they appear in the navigation menu.
@@ -115,7 +125,7 @@ HTML_DST = \
   ${DST}/conduct/index.html \
   ${DST}/setup/index.html \
   $(patsubst _episodes/%.md,${DST}/%/index.html,$(sort $(wildcard _episodes/*.md))) \
-  ${DST}/reference/index.html \
+  ${DST}/reference.html \
   $(patsubst _extras/%.md,${DST}/%/index.html,$(sort $(wildcard _extras/*.md))) \
   ${DST}/license/index.html
 
@@ -128,18 +138,18 @@ lesson-md : ${RMD_DST}
 
 _episodes/%.md: _episodes_rmd/%.Rmd install-rmd-deps
 	@mkdir -p _episodes
-	@bin/knit_lessons.sh $< $@
+	@$(SHELL) bin/knit_lessons.sh $< $@
 
 ## * lesson-check     : validate lesson Markdown
-lesson-check : lesson-fixme
+lesson-check : python lesson-fixme
 	@${PYTHON} bin/lesson_check.py -s . -p ${PARSER} -r _includes/links.md
 
 ## * lesson-check-all : validate lesson Markdown, checking line lengths and trailing whitespace
-lesson-check-all :
+lesson-check-all : python
 	@${PYTHON} bin/lesson_check.py -s . -p ${PARSER} -r _includes/links.md -l -w --permissive
 
 ## * unittest         : run unit tests on checking tools
-unittest :
+unittest : python
 	@${PYTHON} bin/test_lesson_check.py
 
 ## * lesson-files     : show expected names of generated files for debugging
@@ -157,6 +167,22 @@ lesson-fixme :
 ## IV. Auxililary (plumbing) commands
 ## =================================================
 
+.PHONY : commands python
+
 ## * commands         : show all commands.
 commands :
 	@sed -n -e '/^##/s|^##[[:space:]]*||p' $(MAKEFILE_LIST)
+
+python :
+ifeq (, $(PYTHON))
+	$(error $(PYTHON_NOTE))
+else
+	@:
+endif
+
+index.md :
+ifeq (, $(wildcard index.md))
+	$(error index.md not found)
+else
+	@:
+endif

--- a/bin/dependencies.R
+++ b/bin/dependencies.R
@@ -1,17 +1,26 @@
 install_required_packages <- function(lib = NULL, repos = getOption("repos", default = c(CRAN = "https://cran.rstudio.com/"))) {
 
   if (is.null(lib)) {
-    lib <- .libPaths()
+    lib <- .libPaths()[[1]]
   }
 
   message("lib paths: ", paste(lib, collapse = ", "))
-  missing_pkgs <- setdiff(
-    c("rprojroot", "desc", "remotes", "renv"),
-    rownames(installed.packages(lib.loc = lib))
-  )
+  # Note: RMarkdown is needed for renv to detect packages in Rmd documents.
+  required_pkgs <- c("rprojroot", "desc", "remotes", "renv", "BiocManager", "rmarkdown")
+  installed_pkgs <- rownames(installed.packages(lib.loc = lib))
+  missing_pkgs <- setdiff(required_pkgs, installed_pkgs)
 
-  install.packages(missing_pkgs, lib = lib, repos = repos)
+  # The default installation of R will have "@CRAN@" as the default repository,
+  # which directs contrib.url() to either force the user to choose a mirror if
+  # interactive or fail if not. Since we are not interactve, we need to force
+  # the mirror here.
+  if ("@CRAN@" %in% repos) {
+    repos <- c(CRAN = "https://cran.rstudio.com/")
+  }
 
+  if (length(missing_pkgs) != 0) {
+    install.packages(missing_pkgs, lib = lib, repos = repos)
+  }
 }
 
 find_root <- function() {
@@ -22,15 +31,42 @@ find_root <- function() {
   root
 }
 
+# set the BiocManager repositories and return a function that resets the default
+# repositories.
+#
+# @example
+# bioc_repos_example <- function() {
+#   message("User repos")
+#   as.data.frame(getOption("repos"))
+#   reset_repos <- use_bioc_repos()
+#   on.exit(reset_repos())
+#   message("Bioc repos")
+#   as.data.frame(getOption("repos"))
+# }
+# bioc_repos_example()
+# as.data.frame(getOption("repos")
+use_bioc_repos <- function() {
+  repos <- getOption("repos")
+  suppressMessages(options(repos = BiocManager::repositories()))
+  function() {
+    options(repos = repos)
+  }
+}
+
 identify_dependencies <- function() {
 
   root <- find_root()
 
+  reset_repos <- use_bioc_repos()
+  on.exit(reset_repos(), add = TRUE)
+  eps <- file.path(root, "_episodes_rmd")
+  bin <- file.path(root, "bin")
+
   required_pkgs <- unique(c(
     ## Packages for episodes
-    renv::dependencies(file.path(root, "_episodes_rmd"), progress = FALSE, error = "ignore")$Package,
+    renv::dependencies(eps, progress = FALSE, error = "ignored")$Package,
     ## Packages for tools
-    renv::dependencies(file.path(root, "bin"), progress = FALSE, error = "ignore")$Package
+    renv::dependencies(bin, progress = FALSE, error = "ignored")$Package
   ))
 
   required_pkgs
@@ -38,14 +74,30 @@ identify_dependencies <- function() {
 
 create_description <- function(required_pkgs) {
   d <- desc::description$new("!new")
-  lapply(required_pkgs, function(x) d$set_dep(x))
+  d$set_deps(data.frame(type = "Imports", package = required_pkgs, version = "*"))
   d$write("DESCRIPTION")
+  # We have to write the description twice to get the hidden dependencies
+  # because renv only considers explicit dependencies.
+  #
+  # This is needed because some of the hidden dependencis will require system
+  # libraries to be configured.
+  suppressMessages(repo <- BiocManager::repositories())
+  deps <- remotes::dev_package_deps(dependencies = TRUE, repos = repo)
+  deps <- deps$package[deps$diff < 0]
+  if (length(deps)) {
+    # only create new DESCRIPTION file if there are dependencies to install
+    d$set_deps(data.frame(type = "Imports", package = deps, version = "*"))
+    d$write("DESCRIPTION")
+  }
 }
 
 install_dependencies <- function(required_pkgs, ...) {
 
+  reset_repos <- use_bioc_repos()
+  on.exit(reset_repos(), add = TRUE)
+
   create_description(required_pkgs)
-  on.exit(file.remove("DESCRIPTION"))
+  on.exit(file.remove("DESCRIPTION"), add = TRUE)
   remotes::install_deps(dependencies = TRUE, ...)
 
   if (require("knitr") && packageVersion("knitr") < '1.9.19') {

--- a/bin/generate_md_episodes.R
+++ b/bin/generate_md_episodes.R
@@ -1,5 +1,9 @@
 generate_md_episodes <- function() {
 
+  # avoid ansi color characters from being printed in the output
+  op <- options()
+  on.exit(options(op), add = TRUE)
+  options(crayon.enabled = FALSE)
   ## get the Rmd file to process from the command line, and generate the path
   ## for their respective outputs
   args  <- commandArgs(trailingOnly = TRUE)

--- a/bin/lesson_check.py
+++ b/bin/lesson_check.py
@@ -6,10 +6,13 @@ Check lesson files and their contents.
 import os
 import glob
 import re
+import sys
 from argparse import ArgumentParser
 
-from util import (Reporter, read_markdown, load_yaml, check_unwanted_files,
-                  require)
+# This uses the `__all__` list in `util.py` to determine what objects to import
+# see https://docs.python.org/3/tutorial/modules.html#importing-from-a-package
+from util import *
+from reporter import Reporter
 
 __version__ = '0.3'
 
@@ -56,9 +59,24 @@ P_INTERNAL_LINK_DEF = re.compile(r'^\[([^\]]+)\]:\s*(.+)')
 # Pattern to match {% include ... %} statements
 P_INTERNAL_INCLUDE_LINK = re.compile(r'^{% include ([^ ]*) %}$')
 
+# Pattern to match image-only and link-only lines
+P_LINK_IMAGE_LINE = re.compile(r'''
+    [> #]*        # any number of '>', '#', and spaces
+    \W{,3}        # up to 3 non-word characters
+    !?            # ! or nothing
+    \[[^]]+\]     # [any text]
+    [([]          # ( or [
+    [^])]+        # 1+ characters that are neither ] nor )
+    [])]          # ] or )
+    (?:{:[^}]+})? # {:any text} or nothing
+    \W{,3}        # up to 3 non-word characters
+    [ ]*          # any number of spaces
+    \\?$          # \ or nothing + end of line''', re.VERBOSE)
+
 # What kinds of blockquotes are allowed?
 KNOWN_BLOCKQUOTES = {
     'callout',
+    'caution',
     'challenge',
     'checklist',
     'discussion',
@@ -67,25 +85,17 @@ KNOWN_BLOCKQUOTES = {
     'prereq',
     'quotation',
     'solution',
-    'testimonial'
+    'testimonial',
+    'warning'
 }
 
 # What kinds of code fragments are allowed?
+# Below we allow all 'language-*' code blocks
 KNOWN_CODEBLOCKS = {
     'error',
     'output',
     'source',
-    'language-bash',
-    'html',
-    'language-c',
-    'language-cmake',
-    'language-cpp',
-    'language-make',
-    'language-matlab',
-    'language-python',
-    'language-r',
-    'language-shell',
-    'language-sql'
+    'warning'
 }
 
 # What fields are required in teaching episode metadata?
@@ -109,14 +119,28 @@ BREAK_METADATA_FIELDS = {
 # Please keep this in sync with .editorconfig!
 MAX_LINE_LEN = 100
 
+# Contents of _config.yml
+CONFIG = {}
 
 def main():
     """Main driver."""
 
     args = parse_args()
     args.reporter = Reporter()
-    check_config(args.reporter, args.source_dir)
+
+    global CONFIG
+    config_file = os.path.join(args.source_dir, '_config.yml')
+    CONFIG = load_yaml(config_file)
+    CONFIG["config_file"] = config_file
+
+    life_cycle = CONFIG.get('life_cycle', None)
+    # pre-alpha lessons should report without error
+    if life_cycle == "pre-alpha":
+        args.permissive = True
+
+    check_config(args.reporter)
     check_source_rmd(args.reporter, args.source_dir, args.parser)
+
     args.references = read_references(args.reporter, args.reference_path)
 
     docs = read_all_markdown(args.source_dir, args.parser)
@@ -127,8 +151,16 @@ def main():
         checker.check()
 
     args.reporter.report()
-    if args.reporter.messages and not args.permissive:
-        exit(1)
+    if args.reporter.messages:
+        if args.permissive:
+            print("Problems detected but ignored (permissive mode).")
+        else:
+            print("Problems detected.")
+            sys.exit(1)
+    else:
+        print("No problems found.")
+
+    return
 
 
 def parse_args():
@@ -165,33 +197,35 @@ def parse_args():
 
     args, extras = parser.parse_known_args()
     require(args.parser is not None,
-            'Path to Markdown parser not provided')
+            'Path to Markdown parser not provided',
+            True)
     require(not extras,
             'Unexpected trailing command-line arguments "{0}"'.format(extras))
 
     return args
 
-
-def check_config(reporter, source_dir):
+def check_config(reporter):
     """Check configuration file."""
 
-    config_file = os.path.join(source_dir, '_config.yml')
-    config = load_yaml(config_file)
-    reporter.check_field(config_file, 'configuration',
-                         config, 'kind', 'lesson')
-    reporter.check_field(config_file, 'configuration',
-                         config, 'carpentry', ('swc', 'dc', 'lc', 'cp'))
-    reporter.check_field(config_file, 'configuration', config, 'title')
-    reporter.check_field(config_file, 'configuration', config, 'email')
+    reporter.check_field(CONFIG["config_file"], 'configuration',
+                         CONFIG, 'kind', 'lesson')
+    reporter.check_field(CONFIG["config_file"], 'configuration',
+                         CONFIG, 'carpentry', ('swc', 'dc', 'lc', 'cp', 'incubator'))
+    reporter.check_field(CONFIG["config_file"], 'configuration', CONFIG, 'title')
+    reporter.check_field(CONFIG["config_file"], 'configuration', CONFIG, 'email')
 
     for defaults in [
             {'values': {'root': '.', 'layout': 'page'}},
             {'values': {'root': '..', 'layout': 'episode'}, 'scope': {'type': 'episodes', 'path': ''}},
             {'values': {'root': '..', 'layout': 'page'}, 'scope': {'type': 'extras', 'path': ''}}
             ]:
-        reporter.check(defaults in config.get('defaults', []),
-                   'configuration',
-                   '"root" not set to "." in configuration')
+        error_text = 'incorrect settings for: root "{0}" layout "{1}"'
+        root = defaults["values"]["root"]
+        layout = defaults["values"]["layout"]
+        error_message = error_text.format(root, layout)
+
+        defaults_test = defaults in CONFIG.get('defaults', [])
+        reporter.check(defaults_test, 'configuration', error_message)
 
 def check_source_rmd(reporter, source_dir, parser):
     """Check that Rmd episode files include `source: Rmd`"""
@@ -212,6 +246,9 @@ def read_references(reporter, ref_path):
     {symbolic_name : URL}
     """
 
+    if 'remote_theme' in CONFIG:
+        return {}
+
     if not ref_path:
         raise Warning("No filename has been provided.")
 
@@ -221,7 +258,17 @@ def read_references(reporter, ref_path):
     with open(ref_path, 'r', encoding='utf-8') as reader:
         for (num, line) in enumerate(reader, 1):
 
-            if P_INTERNAL_INCLUDE_LINK.search(line): continue
+            # Skip empty lines
+            if len(line.strip()) == 0:
+                continue
+
+            # Skip HTML comments
+            if line.strip().startswith("<!--") and line.strip().endswith("-->"):
+                   continue
+
+            # Skip Liquid's {% include ... %} lines
+            if P_INTERNAL_INCLUDE_LINK.search(line):
+                continue
 
             m = P_INTERNAL_LINK_DEF.search(line)
 
@@ -360,12 +407,19 @@ class CheckBase:
         """Check the raw text of the lesson body."""
 
         if self.args.line_lengths:
-            over = [i for (i, l, n) in self.lines if (
-                n > MAX_LINE_LEN) and (not l.startswith('!'))]
-            self.reporter.check(not over,
+            over_limit = []
+
+            for (i, l, n) in self.lines:
+                # Report lines that are longer than the suggested
+                # line length limit only if they're not
+                # link-only or image-only lines.
+                if n > MAX_LINE_LEN and not P_LINK_IMAGE_LINE.match(l):
+                    over_limit.append(i)
+
+            self.reporter.check(not over_limit,
                                 self.filename,
                                 'Line(s) too long: {0}',
-                                ', '.join([str(i) for i in over]))
+                                ', '.join([str(i) for i in over_limit]))
 
     def check_trailing_whitespace(self):
         """Check for whitespace at the ends of lines."""
@@ -393,7 +447,8 @@ class CheckBase:
 
         for node in self.find_all(self.doc, {'type': 'codeblock'}):
             cls = self.get_val(node, 'attr', 'class')
-            self.reporter.check(cls in KNOWN_CODEBLOCKS,
+            self.reporter.check(cls is not None and (cls in KNOWN_CODEBLOCKS or
+                cls.startswith('language-')),
                                 (self.filename, self.get_loc(node)),
                                 'Unknown or missing code block type {0}',
                                 cls)
@@ -523,6 +578,9 @@ class CheckEpisode(CheckBase):
     def check_reference_inclusion(self):
         """Check that links file has been included."""
 
+        if 'remote_theme' in CONFIG:
+            return
+
         if not self.args.reference_path:
             return
 
@@ -560,7 +618,8 @@ CHECKERS = [
     (re.compile(r'README\.md'), CheckNonJekyll),
     (re.compile(r'index\.md'), CheckIndex),
     (re.compile(r'reference\.md'), CheckReference),
-    (re.compile(os.path.join('_episodes', '*\.md')), CheckEpisode),
+    # '.' below is what's passed on the command line via '-s' flag
+    (re.compile(os.path.join('.','_episodes', '[^/]*\.md')), CheckEpisode),
     (re.compile(r'.*\.md'), CheckGeneric)
 ]
 

--- a/bin/lesson_initialize.py
+++ b/bin/lesson_initialize.py
@@ -6,7 +6,6 @@ import os
 import shutil
 
 BOILERPLATE = (
-    '.travis.yml',
     'AUTHORS',
     'CITATION',
     'CONTRIBUTING.md',

--- a/bin/markdown_ast.rb
+++ b/bin/markdown_ast.rb
@@ -1,11 +1,13 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Use Kramdown parser to produce AST for Markdown document.
 
-require "kramdown"
-require "json"
+require 'kramdown'
+require 'kramdown-parser-gfm'
+require 'json'
 
-markdown = STDIN.read()
-doc = Kramdown::Document.new(markdown)
+markdown = $stdin.read
+doc = Kramdown::Document.new(markdown, input: 'GFM', hard_wrap: false)
 tree = doc.to_hash_a_s_t
 puts JSON.pretty_generate(tree)

--- a/bin/repo_check.py
+++ b/bin/repo_check.py
@@ -9,7 +9,8 @@ from subprocess import Popen, PIPE
 import re
 from argparse import ArgumentParser
 
-from util import Reporter, require
+from util import require
+from reporter import Reporter
 
 # Import this way to produce a more useful error message.
 try:

--- a/bin/reporter.py
+++ b/bin/reporter.py
@@ -1,0 +1,75 @@
+import sys
+
+class Reporter:
+    """Collect and report errors."""
+
+    # Marker to show that an expected value hasn't been provided.
+    # (Can't use 'None' because that might be a legitimate value.)
+    _DEFAULT_REPORTER = []
+
+    def __init__(self):
+        """Constructor."""
+        self.messages = []
+
+    def check_field(self, filename, name, values, key, expected=_DEFAULT_REPORTER):
+        """Check that a dictionary has an expected value."""
+
+        if key not in values:
+            self.add(filename, '{0} does not contain {1}', name, key)
+        elif expected is self._DEFAULT_REPORTER:
+            pass
+        elif type(expected) in (tuple, set, list):
+            if values[key] not in expected:
+                self.add(
+                    filename, '{0} {1} value {2} is not in {3}', name, key, values[key], expected)
+        elif values[key] != expected:
+            self.add(filename, '{0} {1} is {2} not {3}',
+                     name, key, values[key], expected)
+
+    def check(self, condition, location, fmt, *args):
+        """Append error if condition not met."""
+
+        if not condition:
+            self.add(location, fmt, *args)
+
+    def add(self, location, fmt, *args):
+        """Append error unilaterally."""
+
+        self.messages.append((location, fmt.format(*args)))
+
+    @staticmethod
+    def pretty(item):
+        location, message = item
+        if isinstance(location, type(None)):
+            return message
+        elif isinstance(location, str):
+            return location + ': ' + message
+        elif isinstance(location, tuple):
+            return '{0}:{1}: '.format(*location) + message
+
+        print('Unknown item "{0}"'.format(item), file=sys.stderr)
+        return NotImplemented
+
+    @staticmethod
+    def key(item):
+        location, message = item
+        if isinstance(location, type(None)):
+            return ('', -1, message)
+        elif isinstance(location, str):
+            return (location, -1, message)
+        elif isinstance(location, tuple):
+            return (location[0], location[1], message)
+
+        print('Unknown item "{0}"'.format(item), file=sys.stderr)
+        return NotImplemented
+
+    def report(self, stream=sys.stdout):
+        """Report all messages in order."""
+
+        if not self.messages:
+            return
+
+        for m in sorted(self.messages, key=self.key):
+            print(self.pretty(m), file=stream)
+
+

--- a/bin/test_lesson_check.py
+++ b/bin/test_lesson_check.py
@@ -1,12 +1,12 @@
 import unittest
 
 import lesson_check
-import util
+import reporter
 
 
 class TestFileList(unittest.TestCase):
     def setUp(self):
-        self.reporter = util.Reporter()  # TODO: refactor reporter class.
+        self.reporter = reporter.Reporter()  # TODO: refactor reporter class.
 
     def test_file_list_has_expected_entries(self):
         # For first pass, simply assume that all required files are present

--- a/bin/util.py
+++ b/bin/util.py
@@ -10,93 +10,12 @@ except ImportError:
     print('Unable to import YAML module: please install PyYAML', file=sys.stderr)
     sys.exit(1)
 
-
-# Things an image file's name can end with.
-IMAGE_FILE_SUFFIX = {
-    '.gif',
-    '.jpg',
-    '.png',
-    '.svg'
-}
+__all__ = ['check_unwanted_files', 'load_yaml', 'read_markdown', 'require']
 
 # Files that shouldn't be present.
 UNWANTED_FILES = [
     '.nojekyll'
 ]
-
-# Marker to show that an expected value hasn't been provided.
-# (Can't use 'None' because that might be a legitimate value.)
-REPORTER_NOT_SET = []
-
-
-class Reporter:
-    """Collect and report errors."""
-
-    def __init__(self):
-        """Constructor."""
-        self.messages = []
-
-    def check_field(self, filename, name, values, key, expected=REPORTER_NOT_SET):
-        """Check that a dictionary has an expected value."""
-
-        if key not in values:
-            self.add(filename, '{0} does not contain {1}', name, key)
-        elif expected is REPORTER_NOT_SET:
-            pass
-        elif type(expected) in (tuple, set, list):
-            if values[key] not in expected:
-                self.add(
-                    filename, '{0} {1} value {2} is not in {3}', name, key, values[key], expected)
-        elif values[key] != expected:
-            self.add(filename, '{0} {1} is {2} not {3}',
-                     name, key, values[key], expected)
-
-    def check(self, condition, location, fmt, *args):
-        """Append error if condition not met."""
-
-        if not condition:
-            self.add(location, fmt, *args)
-
-    def add(self, location, fmt, *args):
-        """Append error unilaterally."""
-
-        self.messages.append((location, fmt.format(*args)))
-
-    @staticmethod
-    def pretty(item):
-        location, message = item
-        if isinstance(location, type(None)):
-            return message
-        elif isinstance(location, str):
-            return location + ': ' + message
-        elif isinstance(location, tuple):
-            return '{0}:{1}: '.format(*location) + message
-
-        print('Unknown item "{0}"'.format(item), file=sys.stderr)
-        return NotImplemented
-
-    @staticmethod
-    def key(item):
-        location, message = item
-        if isinstance(location, type(None)):
-            return ('', -1, message)
-        elif isinstance(location, str):
-            return (location, -1, message)
-        elif isinstance(location, tuple):
-            return (location[0], location[1], message)
-
-        print('Unknown item "{0}"'.format(item), file=sys.stderr)
-        return NotImplemented
-
-    def report(self, stream=sys.stdout):
-        """Report all messages in order."""
-
-        if not self.messages:
-            return
-
-        for m in sorted(self.messages, key=self.key):
-            print(self.pretty(m), file=stream)
-
 
 def read_markdown(parser, path):
     """
@@ -115,7 +34,7 @@ def read_markdown(parser, path):
              for (i, line) in enumerate(body.split('\n'))]
 
     # Parse Markdown.
-    cmd = 'ruby {0}'.format(parser)
+    cmd = 'bundle exec ruby {0}'.format(parser)
     p = Popen(cmd, shell=True, stdin=PIPE, stdout=PIPE,
               close_fds=True, universal_newlines=True, encoding='utf-8')
     stdout_data, stderr_data = p.communicate(body)
@@ -146,9 +65,8 @@ def split_metadata(path, text):
         try:
             metadata_yaml = yaml.load(metadata_raw, Loader=yaml.SafeLoader)
         except yaml.YAMLError as e:
-            print('Unable to parse YAML header in {0}:\n{1}'.format(
-                path, e), file=sys.stderr)
-            sys.exit(1)
+            message = 'Unable to parse YAML header in {0}:\n{1}'
+            print(message.format(path, e), file=sys.stderr)
 
     return metadata_raw, metadata_yaml, text
 
@@ -162,11 +80,14 @@ def load_yaml(filename):
     try:
         with open(filename, 'r', encoding='utf-8') as reader:
             return yaml.load(reader, Loader=yaml.SafeLoader)
-    except (yaml.YAMLError, IOError) as e:
-        print('Unable to load YAML file {0}:\n{1}'.format(
-            filename, e), file=sys.stderr)
-        sys.exit(1)
+    except yaml.YAMLError as e:
+        message = 'ERROR: Unable to load YAML file {0}:\n{1}'
+        print(message.format(filename, e), file=sys.stderr)
+    except (FileNotFoundError, IOError):
+        message = 'ERROR: File {} not found'
+        print(message.format(filename), file=sys.stderr)
 
+    return {}
 
 def check_unwanted_files(dir_path, reporter):
     """
@@ -180,9 +101,11 @@ def check_unwanted_files(dir_path, reporter):
                        "Unwanted file found")
 
 
-def require(condition, message):
+def require(condition, message, fatal=False):
     """Fail if condition not met."""
 
     if not condition:
         print(message, file=sys.stderr)
-        sys.exit(1)
+
+        if fatal:
+            sys.exit(1)

--- a/bin/workshop_check.py
+++ b/bin/workshop_check.py
@@ -7,7 +7,8 @@ import sys
 import os
 import re
 from datetime import date
-from util import Reporter, split_metadata, load_yaml, check_unwanted_files
+from util import split_metadata, load_yaml, check_unwanted_files
+from reporter import Reporter
 
 # Metadata field patterns.
 EMAIL_PATTERN = r'[^@]+@[^@]+\.[^@]+'
@@ -17,7 +18,7 @@ URL_PATTERN = r'https?://.+'
 
 # Defaults.
 CARPENTRIES = ("dc", "swc", "lc", "cp")
-DEFAULT_CONTACT_EMAIL = 'admin@software-carpentry.org'
+DEFAULT_CONTACT_EMAIL = 'team@carpentries.org'
 
 USAGE = 'Usage: "workshop_check.py path/to/root/directory"'
 


### PR DESCRIPTION
This is another patch to address https://github.com/carpentries/styles/issues/641

Solution: this copies directly the latest versions of the workflows from styles

Problem: the workflows in this repository had not been modified since before we had implemented a workflow that could deploy both markdown and R markdown lessons. It had a custom deploy.yml, which was added in mid-2020. 

[My proposed solution](https://github.com/zkamvar/2022-10-20-workflow-bug#individual-line-replacements) to edit the parts of these files had successfully edited these files, but other parts of these files were invalid so they were never run.

