### PR TITLE
remove un-needed `{: .r}` tag

### DIFF
--- a/_episodes_rmd/07-control-flow.Rmd
+++ b/_episodes_rmd/07-control-flow.Rmd
@@ -327,7 +327,6 @@ output_vector2
 > > ```{r ch10pt12-sol, eval=FALSE}
 > > output_matrix[j, i] <- temp_output
 > > ```
-> > {: .r}
 > {: .solution}
 {: .challenge}
 


### PR DESCRIPTION
I am running the transition for this lesson and found an error that is causing my transformation to not build. I believe this will fix it. 

(see https://github.com/carpentries/lesson-transition/issues/79 for details)
